### PR TITLE
Fixes the include search path to work on case-sensitive file systems

### DIFF
--- a/STM32_Expander/platformio.ini
+++ b/STM32_Expander/platformio.ini
@@ -20,7 +20,7 @@ build_flags =
   -ICubeMX/Core/Inc
   -ICubeMX/Drivers/STM32F1xx_HAL_Driver/Inc
   -ICubeMX/Drivers/STM32F1xx_HAL_Driver/Inc/Legacy
-  -ICubeMx/Drivers/CMSIS/Device/ST/STM32F1xx/Include
+  -ICubeMX/Drivers/CMSIS/Device/ST/STM32F1xx/Include
   -ICubeMX/Drivers/CMSIS/Include
   -specs=nano.specs
   -lgcc


### PR DESCRIPTION
Linux treats files in a case-sensitive manner, and one of the include paths has a lower case x which should be an upper case X (for CubeMX). This fixes it to match the case of the directory.